### PR TITLE
Remover valor default do cálculo de Selic

### DIFF
--- a/src/selic.ts
+++ b/src/selic.ts
@@ -39,12 +39,12 @@ export class Selic {
     return this.calculatePoupancaFromSelic(selic);
   }
 
-  calculateCdiFromSelic(selic: number = 0) {
+  calculateCdiFromSelic(selic: number) {
     const cdi = selic - this.cdiScore;
     return Number(Number(cdi).toFixed(2));
   }
 
-  calculatePoupancaFromSelic(selic: number = 0) {
+  calculatePoupancaFromSelic(selic: number) {
     const poupanca = (selic / 100) * this.poupancaPercent;
     return Number(Number(poupanca).toFixed(2));
   }


### PR DESCRIPTION
Nas funções `calculatePoupancaFromSelic` e `calculateCdiFromSelic`, o parametro `selic` deveria ser obrigatório, pois não faz sentido calcular o selic à partir de `0` (valor definido como default)